### PR TITLE
機能実装バグ報告issueを改善

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,6 +10,15 @@ body:
       description: 発生している問題について簡単に記載してください
     validations:
       required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: 期待される動作
+      description: 本来はどのように動作するべきだったかを記載してください
+    validations:
+      required: false
+
   - type: textarea
     id: notes
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,19 +1,28 @@
-name: 要望・提案
-description: 新機能や改善案の提案用テンプレート
+name: 機能実装
+description: 実装する新機能や改善のタスク用テンプレート
 title: "[Feature] "
 labels: ["enhancement"]
 body:
   - type: textarea
     id: feature_description
     attributes:
-      label: 要望・提案内容
-      description: どんな機能や改善を希望するか簡単に記載してください
+      label: 実装内容
+      description: 実装する機能や改善の概要を記載してください（何を、なぜ）
     validations:
       required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 完了の定義
+      description: このIssueが完了となる条件（画面表示、API、動作など）を簡潔に
+    validations:
+      required: false
+
   - type: textarea
     id: notes
     attributes:
       label: 補足情報
-      description: その他必要な情報があれば記載してください（任意）
+      description: 画面キャプチャや関連Issue、参考URLなど（任意）
     validations:
       required: false


### PR DESCRIPTION
## 概要

既存のIssueテンプレートに対して以下の修正を行った。

- `bug.yml`: 「期待される動作」の入力欄を追加
- `feature.yml`: 名前を「要望・提案」から「機能実装」に変更し、記載内容を実装タスク向けに調整

## 目的

- バグ報告時に「何が期待されていたか」を明示できるようにし、再現・修正を容易にする
- 提案ベースではなく、実装タスクとしての機能Issueテンプレートを用意し、粒度を揃える

## 変更内容

- `.github/ISSUE_TEMPLATE/bug.yml`
  - `expected_behavior` フィールドを追加
- `.github/ISSUE_TEMPLATE/feature.yml`
  - `name`, `description`, フィールド構成の修正（要望ベース → 実装ベース）

## 関連Issue

- closes #3

## 備考

- `feature_request.yml` は別途維持予定（要望用）
