### PR TITLE
#28 report_dateがnullableになる問題を解消

### DIFF
--- a/db/migrate/20250425043047_change_column_not_null_to_reports.rb
+++ b/db/migrate/20250425043047_change_column_not_null_to_reports.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNotNullToReports < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :reports, :report_date, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_25_034426) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_25_043047) do
   create_table "reports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "contents", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.date "report_date"
+    t.date "report_date", null: false
     t.index ["user_id"], name: "index_reports_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
`reports.report_date`が`nullable`になってしまう問題を認めたため、`notNullable`になるように修正を実施した。

## ISSUE

close #28

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。
・機能面: 日報に関するCRUDページ
・DB: reportsテーブルのreport_dateをnotNullableとなるように調整。


## レビュアーへのコメント (任意 / 推奨)
以下のコマンドによりmigration可能。
1. `bundle exec rails db:reset`
2. `bundle exec rails db:migrate`
3. `bundle exec rails db:seed`

![CleanShot 2025-04-25 at 13 36 18](https://github.com/user-attachments/assets/213c29cd-76d5-4124-bbf1-0050cee69620)


## QA (確認事項)

* [ ] migrationすることにより、db上の`report_date`がnotNullableになること
  CLIで確認する場合 `show columns from reports;`
