### PR TITLE
#21 deviceの設定を変更し、新規ユーザー登録から登録できるように修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name role])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name role])
+  end
 end


### PR DESCRIPTION
## 概要

新規ユーザー登録画面からuserのnameとroleを正しく保存できない不具合の修正

## ISSUE

Closes #21 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** 新規ユーザー登録の画面
* **データベース:** user table

## レビュアーへのコメント (任意 / 推奨)

主にdeviceの権限周りを変更しました。
device周りでエラーが出たらまたここら辺を修正した方がいいかも。

<details>
<summary>変更の詳細</summary>
deviceがそもそもユーザー登録の画面からemailとpasswordというパラメーターしか送れないようになっていた。(権限がなかった)


なので、nameとroleというパラメーターをユーザー登録の画面から送れるように修正しました。
</details>

## QA (確認事項)
- 新規ユーザー登録の画面からユーザーを追加したときにDB側にただしくuserのnameとroleを保存されているかを確認

* [ ] (例) 期待通りにページが表示されることを確認した
