### PR TITLE
Fix/41 詳細ページについて日時関連の情報を正しく表示

### DIFF
--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -7,6 +7,11 @@
       <h4 class="card-title text-primary"><strong>タイトル:</strong> <%= @report.title %></h4>
 
       <div class="mb-4 border-start border-3 border-primary ps-3">
+        <strong>日付:</strong>
+        <p class="lead"><%= @report.report_date.strftime("%Y-%m-%d") %></p>
+      </div>
+
+      <div class="mb-4 border-start border-3 border-primary ps-3">
         <strong>内容:</strong>
         <p class="lead"><%= simple_format(@report.contents) %></p>
       </div>
@@ -14,6 +19,7 @@
       <ul class="list-unstyled">
         <li><strong>作成者:</strong> <%= @report.user&.name %></li>
         <li><strong>作成日時:</strong> <%= @report.created_at.strftime("%Y-%m-%d %H:%M") %></li>
+        <li><strong>更新日時:</strong> <%= @report.updated_at.strftime("%Y-%m-%d %H:%M") %></li>
       </ul>
     </div>
     <div class="card-footer text-center">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -5,6 +5,10 @@
     </div>
     <div class="card-body">
       <h4 class="card-title text-primary"><strong>タイトル:</strong> <%= @report.title %></h4>
+      <div class="mb-4 border-start border-3 border-primary ps-3">
+        <strong>日付:</strong>
+        <p class="lead"><%= @report.report_date.strftime("%Y-%m-%d") %></p>
+      </div>
 
       <div class="mb-4 border-start border-3 border-primary ps-3">
         <strong>内容:</strong>
@@ -12,7 +16,8 @@
       </div>
 
       <ul class="list-unstyled">
-        <li><strong>作成日:</strong> <%= @report.created_at.strftime("%Y-%m-%d %H:%M") %></li>
+        <li><strong>作成日時:</strong> <%= @report.created_at.strftime("%Y-%m-%d %H:%M") %></li>
+        <li><strong>更新日時:</strong> <%= @report.updated_at.strftime("%Y-%m-%d %H:%M") %></li>
       </ul>
     </div>
 <div class="card-footer text-center">


### PR DESCRIPTION
## 概要

詳細ページの日時関連を正しく変更。
**userページ**
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/47b15d41-5f96-4098-8783-64cd09c8da47" />


**adminページ**
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/7294d197-bfd3-408c-98b0-5186774c42b1" />


## ISSUE

Closes #41 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

* **UI/UX:** userの詳細ページ・adminの詳細ページ

## レビュアーへのコメント (任意 / 推奨)

## QA (確認事項)

- [ ] userの詳細ページが正しく実装できているか
- [ ] adminの詳細ページが正しく実装できているか

* [ ] (例) 期待通りにページが表示されることを確認した
