### PR TITLE
Fix/43 一覧ページの日付を正しく表示できるように修正

### DIFF
--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -7,7 +7,7 @@
       <th>ID</th>
       <th>タイトル</th>
       <th>作成者</th>
-      <th>作成日時</th>
+      <th>日付</th>
       <th>操作</th>
     </tr>
   </thead>
@@ -17,7 +17,7 @@
         <td><%= report.id %></td>
         <td><%= report.title %></td>
         <td><%= report.user&.name %></td>
-        <td><%= l(report.created_at, format: :short) %></td>
+        <td><%= report.report_date.strftime("%Y-%m-%d") %></td>
         <td>
           <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm" %>
           <%= button_to "削除", admin_report_path(report), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,14 +1,13 @@
 <% if user_signed_in? %>
   <h1>Welcome, <%= current_user.name %></h1>
-  
   <% if current_user.admin? %>
     <!-- 管理者の場合 -->
     <p>管理者専用の機能にアクセスできます。</p>
     <%= link_to "管理者ダッシュボード", admin_root_path, class: "btn btn-primary" %>
     <p>あなたの日報管理機能にアクセスできます。</p>
     <div class="reports">
-    <%= link_to "日報を作成", new_report_path, class: "btn btn-success" %>
-    <%= link_to "日報一覧", reports_path, class: "btn btn-secondary" %>
+      <%= link_to "日報を作成", new_report_path, class: "btn btn-success" %>
+      <%= link_to "日報一覧", reports_path, class: "btn btn-secondary" %>
     </div>
   <% else %>
     <!-- 一般ユーザーの場合 -->
@@ -16,9 +15,7 @@
     <%= link_to "日報を作成", new_report_path, class: "btn btn-success" %>
     <%= link_to "日報一覧", reports_path, class: "btn btn-secondary" %>
   <% end %>
-
   <h2 class="mb-4">新着日報</h2>
-
   <% if @reports.any? %>
     <table class="table table-hover">
       <thead class="table-dark">
@@ -33,8 +30,8 @@
         <% @reports.each do |report| %>
           <tr>
             <td><%= report.title %></td>
-            <td><%= report.user.name %></td> <!-- 作成者を表示 -->
-            <td><%= report.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+            <td><%= report.user.name %></td>
+            <td><%= report.report_date.strftime("%Y-%m-%d")  %></td>
             <td>
               <% if current_user.admin? %>
                 <%= link_to "詳細を見る", admin_report_path(report), class: "btn btn-outline-danger btn-sm" %>
@@ -51,7 +48,6 @@
       現在、新着の日報はありません。
     </div>
   <% end %>
-  
 <% else %>
   <h1>Welcome to Daily Report System</h1>
   <p>アカウントをお持ちでない方は、ユーザー登録をお願いします。</p>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -6,7 +6,7 @@
       <th>ID</th>
       <th>タイトル</th>
       <th>作成者</th>
-      <th>作成日時</th>
+      <th>日付</th>
       <th>操作</th>
     </tr>
   </thead>
@@ -16,7 +16,7 @@
         <td><%= report.id %></td>
         <td><%= report.title %></td>
         <td><%= report.user&.name %></td>
-        <td><%= l(report.created_at, format: :short) %></td>
+        <td><%= report.report_date.strftime("%Y-%m-%d") %></td>
         <td>
           <%= link_to "詳細", report_path(report), class: "btn btn-primary btn-sm" %>
           <%= button_to "削除", report_path(report), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>


### PR DESCRIPTION
## 概要

一覧ページの日付を正しく表示できるように修正

**userの日報一覧ページ**
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/c0b51789-2521-4f3b-9f3f-b88eda8ab753" />

**adminの日報一覧ページ**
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/c2ddca1e-84ff-42fe-9108-c6ad02189afe" />


## ISSUE

該当するISSUEリンク

Closes #43 

## 変更の種類(必須)
該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

* **UI/UX:** userとadminの日報一覧ページ

## レビュアーへのコメント (任意 / 推奨)

## QA (確認事項)

* [ ] userの日報一覧ページに関して正しく実装できているか
* [ ] adminの日報一覧ページに関して正しく実装できているか

* [ ] (例) 期待通りにページが表示されることを確認した
