### PR TITLE
Fix/#39 存在しないページにアクセスしようとしたらnot found ページにリダイレクトされるように修正

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,22 +1,21 @@
 class Admin::ReportsController < Admin::BaseController
-  before_action :set_report, only: [:show, :destroy]
+  before_action :set_report, only: %i[show destroy]
 
   def index
     @reports = Report.all.order(created_at: :desc)
   end
 
-  def show
-    @report = Report.find(params[:id])
-  end
+  def show; end
 
   def destroy
     @report.destroy
-    redirect_to admin_reports_path, notice: "日報が削除されました。"
+    redirect_to admin_reports_path, notice: '日報が削除されました。'
   end
 
   private
 
   def set_report
-    @report = Report.find(params[:id])
+    @report = Report.find_by(id: params[:id])
+    not_found unless @report
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def not_found
+    render status: :not_found, template: 'errors/not_found'
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,6 +7,7 @@ class ReportsController < ApplicationController
 
   def show
     @report = Report.find_by(id: params[:id], user_id: current_user.id)
+    not_found unless @report
   end
   
   def new

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,18 @@
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 text-center">
+      <h1 class="display-4 mb-4">404 Not Found</h1>
+      <p class="lead mb-4">お探しのページは存在しません。</p>
+      <p class="mb-4">5秒後に自動的にトップページに移動します。</p>
+      <div class="mb-4">
+        <%= link_to "トップページに戻る", root_path, class: "btn btn-primary" %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  setTimeout(function() {
+    window.location.href = "<%= root_path %>";
+  }, 5000);
+</script> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  root "home#index"
-  
-  resources :users, only: [:index, :show, :edit, :update, :destroy]
+  root 'home#index'
+
+  resources :users, only: %i[index show edit update destroy]
   resources :reports
 
   namespace :admin do
@@ -15,8 +15,10 @@ Rails.application.routes.draw do
     get 'users/edit'
     get 'users/update'
     get 'users/destroy'
-    root "dashboard#index"
-    resources :users, only: [:index, :new, :create, :edit, :update, :destroy]
-    resources :reports, only: [:index, :show, :destroy]
+    root 'dashboard#index'
+    resources :users, only: %i[index new create edit update destroy]
+    resources :reports, only: %i[index show destroy]
   end
+
+  match '*path', to: 'application#not_found', via: :all
 end


### PR DESCRIPTION
## 概要

本来アクセスできないページにアクセスしようとしたときにnot found のページに飛ばすように修正しました。
- /hoge
- reports/[:id]  : まだ作成していないreport_id

## ISSUE

#39 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** 詳細ページ・まだ存在しないページ

## レビュアーへのコメント (任意 / 推奨)

- formatterの影響で関係ないところも差分に含まれてます。すみません。
- 更新や削除のページについてもこの問題が起こりうるので**まだissueは閉じないほうがいい**と思う

## QA (確認事項)

存在しないページにアクセスした時の確認
* [x] http://localhost:3000/hoge

まだ作っていないreportにアクセスした時の確認
adminとしてログインして以下のページにアクセスして確認
* [x] http://localhost:3000/reports/100
* [x] http://localhost:3000/admin/reports/100

userとしてログインして以下のページにアクセスして確認
* [x] http://localhost:3000/reports/100