### PR TITLE
Fix/40 adminの日報一覧にある不要なボタンの削除

### DIFF
--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -1,6 +1,4 @@
 <h1 class="mb-4">日報一覧</h1>
-<%= link_to "新規作成", new_report_path, class: "btn btn-success me-2" %>
-<%= link_to "従業員一覧", admin_users_path, class: "btn btn-primary" %>
 <table class="table table-striped">
   <thead class="table-dark">
     <tr>


### PR DESCRIPTION
## 概要

adminの日報一覧にある不要なボタンの削除
- 新規作成ボタン
- 従業員一覧ボタン

## ISSUE

close #40 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [x] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** adminの日報一覧画面

## レビュアーへのコメント (任意 / 推奨)

## QA (確認事項)

確認したことをリストアップしてください
* [x] http://localhost:3000/admin/reports にアクセスした時に以下のような画面になっているかを確認(新規作成ボタンと従業員一覧ボタンが表示されないことを確認)

 <img width="1467" alt="image" src="https://github.com/user-attachments/assets/feee30c3-319c-4d9e-a69a-67a2d1276472" />

