### PR TITLE
Fix/66 ユーザー登録・更新時のバリデーション

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,7 +27,7 @@ class Admin::UsersController < Admin::BaseController
       redirect_to admin_users_path, notice: "ユーザー情報が更新されました。"
     else
       flash.now[:alert] = "ユーザー情報の更新に失敗しました。"
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,7 +14,7 @@ class Admin::UsersController < Admin::BaseController
     if @user.save
       redirect_to admin_users_path, notice: "ユーザーが作成されました。"
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,12 @@ class User < ApplicationRecord
 
   has_many :reports, dependent: :destroy
 
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :email, presence: true, uniqueness: true, length: { maximum: 255 }
+  validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
+  validates :password_confirmation, presence: true, if: :password_required?
+  # role はデフォルトで1が選択されているため、バリデーションは不要
+
   # role が 0 なら管理者
   def admin?
     role == 0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,17 @@ class User < ApplicationRecord
   def admin?
     role == 0
   end
+
+  def ordered_errors
+    order = [:name, :email, :password, :password_confirmation]
+    ordered_messages = []
+  
+    # 実際にエラーが発生している属性に基づいて順序を適用
+    order.each do |attribute|
+    errors.full_messages_for(attribute).each do |message|
+        ordered_messages << message
+      end
+    end
+    ordered_messages
+  end
 end

--- a/app/views/admin/users/_user_error.erb
+++ b/app/views/admin/users/_user_error.erb
@@ -1,0 +1,10 @@
+<% if @user.errors.any? %>
+  <div class="alert alert-danger">
+    <h4>以下のエラーがあります:</h4>
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/admin/users/_user_error.erb
+++ b/app/views/admin/users/_user_error.erb
@@ -2,7 +2,7 @@
   <div class="alert alert-danger">
     <h4>以下のエラーがあります:</h4>
     <ul>
-      <% user.errors.full_messages.each do |message| %>
+      <% user.ordered_errors.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>

--- a/app/views/admin/users/_user_error.erb
+++ b/app/views/admin/users/_user_error.erb
@@ -1,8 +1,8 @@
-<% if @user.errors.any? %>
+<% if user.errors.any? %>
   <div class="alert alert-danger">
     <h4>以下のエラーがあります:</h4>
     <ul>
-      <% @user.errors.full_messages.each do |message| %>
+      <% user.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,5 +1,5 @@
 <h1 class="mb-4">ユーザー編集</h1>
-
+<%= render 'user_error', user: @user %>
 <%= form_with model: [:admin, @user], local: true, class: "needs-validation" do |f| %>
   <div class="mb-3">
     <%= f.label :name, "名前", class: "form-label" %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,5 +1,5 @@
 <h1 class="mb-4">新規ユーザー作成</h1>
-
+<%= render 'user_error', user: @user %>
 <%= form_with model: [:admin, @user], local: true, class: "needs-validation" do |f| %>
   <div class="mb-3">
     <%= f.label :name, "名前", class: "form-label" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,11 @@ ja:
         report_date: ""
         title: ""
         contents: ""
+      user:
+        name: ""
+        email: ""
+        password: ""
+        password_confirmation: ""
     errors:
       models:
         report:
@@ -16,3 +21,17 @@ ja:
               blank: "タイトルを入力してください"
             contents:
               blank: "内容を入力してください"
+        user:
+          attributes:
+            name:
+              blank: "名前を入力してください"
+            email:
+              blank: "メールアドレスを入力してください"
+              invalid: "メールアドレスの形式が不正です"
+              taken: "このメールアドレスはすでに使用されています"
+            password:
+              blank: "パスワードを入力してください"
+              too_short: "パスワードは %{count} 文字以上で入力してください"
+            password_confirmation:
+              blank: "パスワード（確認用）を入力してください"
+              confirmation: "パスワードと確認用パスワードが一致しません"


### PR DESCRIPTION
## 概要

ユーザー登録・更新時のバリデーション


### 備考
表示されるメッセージはデフォの英語のまま

## ISSUE

close #66 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** (例: ログイン機能、商品一覧ページ、決済処理)
* **UI/UX:** (例: ヘッダーのデザイン変更、ボタンの配置変更)
* **データベース:** (例: `users`テーブルに`last_login_at`カラム追加)
* **外部連携:** (例: 〇〇APIへのリクエストパラメータ変更)
* **影響なし**

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)


### 作成・編集ともに

- [x] ユーザー名が空の状態で作成ボタンを押すとエラーが表示される
- [x] emailが空の状態で作成ボタンを押すとエラーが表示される
- [x] パスワードが空の状態 or 6文字以下の状態で作成ボタンを押すと場合エラーが表示される  

<img width="984" alt="image" src="https://github.com/user-attachments/assets/add40bac-90ad-48fe-969c-704e6323a32b" />

<img width="986" alt="image" src="https://github.com/user-attachments/assets/b707039f-b325-4ab4-b241-e509536cdec9" />


- [x] パスワードとパスワード確認の値が異なる場合エラーが表示される

<img width="982" alt="image" src="https://github.com/user-attachments/assets/40f9a533-b65d-4778-b947-1298dd70e0cc" />



