### PR TITLE
Fix/78 adminの記事一覧ページと記事詳細ページでもお気に入りの状態を変更できるように

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -6,13 +6,16 @@ class FavoritesController < ApplicationController
     @favorite = current_user.favorites.build(report: @report)
 
     if @favorite.save
-      # HACK: 全体再読み込みではなく、1レポート、もしくはお気に入りボタンのみ再読込したい
-      # render turbo_stream: turbo_stream.replace(
-      #   'favorite-button-' + @report.id,
-      #   partial: 'reports/favorite',
-      #   locals: { report: @report, favorite: @favorite },
-      # )
-      redirect_to request.referer
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "favorite-button-#{@report.id}",
+            partial: 'reports/favorite',
+            locals: { report: @report, favorite: @favorite }
+          )
+        end
+        format.html { redirect_to request.referer }
+      end
     else
       redirect_to request.referer
     end
@@ -23,11 +26,15 @@ class FavoritesController < ApplicationController
     @report = @favorite.report
 
     @favorite.destroy
-    # render turbo_stream: turbo_stream.replace(
-    #   'favorite-button-' + @report.id,
-    #   partial: 'reports/favorite',
-    #   locals: { report: @report, favorite: @favorite },
-    # )
-    redirect_to request.referer
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          "favorite-button-#{@report.id}",
+          partial: 'reports/favorite',
+          locals: { report: @report, favorite: nil }
+        )
+      end
+      format.html { redirect_to request.referer }
+    end
   end
 end

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -19,8 +19,11 @@
         <td><%= report.title %></td>
         <td><%= report.user&.name %></td>
         <td><%= report.report_date.strftime("%Y-%m-%d") %></td>
-        <td>
-          <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm" %>
+        <td class="d-flex align-items-center">
+          <div class="me-2">
+            <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>
+          </div>
+          <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm m-0 me-2" %>
           <%= button_to "削除", admin_report_path(report), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>
         </td>
       </tr>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -22,12 +22,19 @@
         <li><strong>更新日時:</strong> <%= @report.updated_at.strftime("%Y-%m-%d %H:%M") %></li>
       </ul>
     </div>
-    <div class="card-footer text-center">
-      <% if current_user.admin? %>
-        <%= link_to "日報一覧へ戻る", admin_reports_path, class: "btn btn-outline-danger btn-lg" %>
-      <% else %>
-        <%= link_to "日報一覧へ戻る", reports_path, class: "btn btn-outline-secondary btn-lg" %>
-      <% end %>
-    </div>
+    <div class="card-footer d-flex align-items-center justify-content-center">
+      <div class="me-3">
+        <%= render partial: "reports/favorite", locals: { report: @report, favorite: @report.favorites.find_by(user_id: current_user.id) } %>
+      </div>
+      <div class="me-2">
+        <% if current_user.admin? %>
+          <%= link_to "日報一覧へ戻る", admin_reports_path, class: "btn btn-outline-danger btn-lg" %>
+        <% else %>
+          <%= link_to "日報一覧へ戻る", reports_path, class: "btn btn-outline-secondary btn-lg" %>
+        <% end %>
+      </div>
+      <%= link_to "編集", edit_report_path(@report), class: "btn btn-outline-primary btn-lg me-2" %>
+      <%= button_to "削除", report_path(@report), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-lg", form: { style: 'display:inline-block;' } %>
+      </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要

- adminの記事一覧・詳細ページでお気に入りの状態を更新できるように修正
- partial renderingも地味に実装できたので、余裕あれば確認してください

## ISSUE

Close #78

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [x] 新機能 (New feature)
* [x] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** adminの記事一覧ページとadminの記事詳細ページ

## レビュアーへのコメント (任意 / 推奨)

mustで確認して欲しいこと(adminページでいいねできるか)
* [ ] http://localhost:3000/admin/reports でいいねが正しく変更できるか
* [ ] http://localhost:3000/admin/reports/[id] でいいねが正しく変更できるか

もし時間があれば(partial renderingの確認)
* [ ] いいねボタンを押した時にいいねボタンだけが再レンダリングされているかを確認(開発者ツール開きながら)

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] (例) 期待通りにページが表示されることを確認した
