### PR TITLE
Fix/59 編集ページで存在しないページにアクセスしたらnot_foundに飛ぶように修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,6 @@
 class ReportsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_report, only: [:edit, :update, :destroy]
+  before_action :set_report, only: %i[show edit update destroy]
 
   def index
     start_date = params[:start_date]
@@ -10,15 +10,12 @@ class ReportsController < ApplicationController
       @reports = Report.where(user_id: current_user.id).order(created_at: :desc)
     else
       @reports = Report.where(user_id: current_user.id)
-                     .by_date_range(start_date, end_date)
-                     .order(created_at: :desc)
+                       .by_date_range(start_date, end_date)
+                       .order(created_at: :desc)
     end
   end
 
-  def show
-    @report = Report.find_by(id: params[:id], user_id: current_user.id)
-    not_found unless @report
-  end
+  def show; end
 
   def new
     @report = current_user.reports.build
@@ -27,7 +24,7 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.build(report_params)
     if @report.save
-      redirect_to reports_path, notice: "日報が作成されました。"
+      redirect_to reports_path, notice: '日報が作成されました。'
     else
       render :new, status: :unprocessable_entity
     end
@@ -36,7 +33,7 @@ class ReportsController < ApplicationController
   def update
     @report.update(report_params)
     if @report.save
-      redirect_to reports_path, notice: "日報を更新しました。"
+      redirect_to reports_path, notice: '日報を更新しました。'
     else
       render :edit, status: :unprocessable_entity
     end
@@ -44,13 +41,14 @@ class ReportsController < ApplicationController
 
   def destroy
     @report.destroy
-    redirect_to reports_path, notice: "日報が削除されました。"
+    redirect_to reports_path, notice: '日報が削除されました。'
   end
 
   private
 
   def set_report
-    @report = current_user.reports.find(params[:id])
+    @report = current_user.reports.find_by(id: params[:id])
+    not_found unless @report
   end
 
   def report_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -31,8 +31,7 @@ class ReportsController < ApplicationController
   end
 
   def update
-    @report.update(report_params)
-    if @report.save
+    if @report.update(report_params)
       redirect_to reports_path, notice: '日報を更新しました。'
     else
       render :edit, status: :unprocessable_entity


### PR DESCRIPTION
## 概要

一般ユーザーで存在しない日報の編集ページに飛んだ時にエラー画面が出てしまっていた。
これを修正し、not_foundのページに飛ぶように修正

## ISSUE

Close #59 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **UI/UX:** ユーザーの日報編集ページ

## レビュアーへのコメント (任意 / 推奨)

* [x] [このページ](http://localhost:3000/reports/100/edit)にアクセスしたときに以下のようなぺ画面が表示されるかを確認
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/2f2d88d4-ce9c-4d5a-ba5d-8fa0e592be5b" />


## QA (確認事項)

確認したことをリストアップしてください。

* [x] (例) 期待通りにページが表示されることを確認した
