### PR TITLE
#127 新規登録時、フォーム上に出るエラーメッセージをtoastに表示

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,82 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
 import "./menu";
+
+// エラーメッセージを保持する配列
+let validationErrors = [];
+
+function clearValidationErrors() {
+  validationErrors = [];
+}
+
+// エラーメッセージを整形する関数
+function formatErrorMessages(errors) {
+  // フィールド名を抽出
+  const fieldNames = errors
+    .filter(error => error.endsWith('を入力してください。'))
+    .map(error => error.replace('を入力してください。', ''));
+
+  // その他のエラーメッセージを抽出
+  const otherErrors = errors.filter(error => !error.endsWith('を入力してください。'));
+
+  // メッセージを組み立て
+  let message = '';
+
+  if (fieldNames.length > 0) {
+    message = `${fieldNames.join('・')}を入力してください。`;
+  }
+
+  if (otherErrors.length > 0) {
+    if (message) message += '<br>';
+    message += otherErrors.join('<br>');
+  }
+
+  return message;
+}
+
+document.addEventListener('invalid', e => {
+  e.preventDefault();
+
+  // フィールド名を取得
+  const fieldName = e.target.getAttribute('name');
+  const label = e.target.labels?.[0]?.textContent || fieldName;
+  let errorMessage = e.target.validationMessage;
+
+  // デフォルトのメッセージをカスタマイズ（toastになると「このフィールド」では分からないため）
+  if (errorMessage === 'このフィールドを入力してください。') {
+    errorMessage = `${label}を入力してください。`;
+  } else if (errorMessage === 'Please fill out this field.') {
+    errorMessage = `Please enter ${label}.`;
+  }
+
+  if (!validationErrors.includes(errorMessage)) {
+    validationErrors.push(errorMessage);
+  }
+
+  // 既存のタイマーをクリア
+  if (window.validationErrorTimer) {
+    clearTimeout(window.validationErrorTimer);
+  }
+
+  // 新しいタイマーを設定（100ms後にエラーメッセージを表示）
+  window.validationErrorTimer = setTimeout(() => {
+    // ToastControllerを使用してエラーメッセージを表示
+    const toastController = document.querySelector('[data-controller="toast"]');
+    if (toastController) {
+      const controller = Stimulus.getControllerForElementAndIdentifier(toastController, 'toast');
+      if (controller) {
+        controller.showError(formatErrorMessages(validationErrors));
+      }
+    }
+    // エラーメッセージをクリア
+    clearValidationErrors();
+  }, 100);
+}, true);
+
+// フォームのsubmitイベントでエラーメッセージをクリア
+document.addEventListener('submit', () => {
+  clearValidationErrors();
+  if (window.validationErrorTimer) {
+    clearTimeout(window.validationErrorTimer);
+  }
+});

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -9,4 +9,25 @@ export default class extends Controller {
       toast.show();
     });
   }
+
+  showError(message) {
+    const toastContainer = this.element;
+    const toastId = `toast-${Date.now()}`;
+
+    const toastHtml = `
+      <div id="${toastId}" class="mb-2 toast toast-danger" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="toast-header toast-header-danger">
+          <i class="bi bi-exclamation-circle me-2"></i>
+          <strong class="me-auto toast-title-danger">Error</strong>
+          <button class="btn-close" data-bs-dismiss="toast"></button>
+        </div>
+        <div class="toast-body toast-body-danger">${message}</div>
+      </div>
+    `;
+
+    toastContainer.insertAdjacentHTML('beforeend', toastHtml);
+    const toastElement = document.getElementById(toastId);
+    const toast = new Toast(toastElement, { autohide: true });
+    toast.show();
+  }
 }


### PR DESCRIPTION
## #139 を先にマージしたほうが良いです！

## 概要

> 新規登録項目に不正な値がある場合、エラーが表示されるべきだが、されない。
現状はフィールドに対しての入力が促されるのみ。
ここも共通でトーストで出せたら嬉しい。

フィールド上に出るエラーをjsで検知して、toastコントローラーを利用して通知を行う。
ISSUEにある画像のエラーは、HTMLのデフォルトバリデーションのメッセージです。
どうやらrails経由のエラーでないようなので、jsでinvalidを監視して、エラーを生成しています。
また、一度に複数のtoastが出るのはよろしくないので、一定時間内で検知したエラーはまとめて１つのtoastでまとめて出力しています。

https://github.com/user-attachments/assets/ffe66ada-263a-4782-91e7-559edcb38e1c


## ISSUE

該当するISSUEリンク
close #127

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **UI/UX:** 
  * 新規ユーザー登録/ログイン時のエラー表示

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] 新規登録時のフォーム上のエラーをtoastで表示すること
  - emailの構文がおかしかったり、入力されていない項目など
* [ ] ログイン時のエラーをtoastで表示すること
  - 例えば、emailの構文がおかしいとか
