### PR TITLE
#140 memberでログイン中にadminのカレンダーにアクセスできてしまう

### DIFF
--- a/app/controllers/admin/calendar_controller.rb
+++ b/app/controllers/admin/calendar_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CalendarController < ApplicationController
+class Admin::CalendarController < Admin::BaseController
   before_action :authenticate_user!
   def day
     start_date = params[:start_date]


### PR DESCRIPTION
## 概要

- memberでadminのカレンダー画面に遷移できてしまう問題があった
- adminのカレンダーのcontrollerに対してadminのBaseControllerを適応して対応

## ISSUE

Closes #140 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

* **UI/UX:** adminのcalendarページ

## レビュアーへのコメント (任意 / 推奨)

memberでログインして以下のページにアクセスできないようになっているか確認
* [x] http://localhost:3000/admin/calendar/month
* [x] http://localhost:3000/admin/calendar/day

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] (例) 期待通りにページが表示されることを確認した
