### PR TITLE
#147 formで表示される日付を決定する　

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,2 +1,13 @@
 module ReportsHelper
+  # _formで表示される日報の日付を決定する
+  # 優先順位:
+  # 1. report.report_date
+  # 2. URLパラメータのdate
+  # 3. 今日の日付
+  def determine_report_date(report)
+    return report.report_date if report.report_date.present?
+    return Date.parse(params[:date]) if params[:date].present?
+
+    Date.today
+  end
 end

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -9,7 +9,9 @@
   <div class="mb-4">
     <div class="d-flex align-items-center mb-2">
       <%= form.label :report_date, '日付', class: "form-label me-2 mb-0 fw-bold" %>
-      <%= form.date_field :report_date, value: (report.report_date || Date.today), class: "form-control form-control-lg w-auto" %>
+      <%= form.date_field :report_date,
+          value: determine_report_date(report),
+          class: "form-control form-control-lg w-auto" %>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要

develop3とdevelop2のマージに伴い、カレンダーからの日報新規作成の際、formで該当日が自動挿入されなくなってしまっている。
以下の優先順位で、挿入する日付を決定して日報の日付を自動設定。
1. report.report_date
2. URLパラメータのdate
3. 今日の日付

## ISSUE

close #147

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **UI/UX:** 日報新規作成時・編集時にフォームに日付が挿入されるロジックの変更

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] カレンダーから任意の日付を選択して新規作成した際に、選択した日付がフォームに入ること。
* [ ] カレンダー以外から新規作成する場合は、本日の日付が入ること。
* [ ] 編集する際は登録済みの日報の日付が表示されること
