### PR TITLE
Fix/146 path change

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -35,7 +35,7 @@ class Admin::ReportsController < Admin::BaseController
   def update
     @report.update(report_params)
     if @report.save
-      redirect_to admin_reports_path, notice: "日報を更新しました。"
+      redirect_to admin_calendar_month_path, notice: "日報を更新しました。"
     else
       @admin_context = true
       flash.now[:alert] = @report.formatted_error_messages
@@ -45,7 +45,7 @@ class Admin::ReportsController < Admin::BaseController
 
   def destroy
     @report.destroy
-    redirect_to admin_reports_path, notice: '日報が削除されました。'
+    redirect_to admin_calendar_month_path, notice: '日報が削除されました。'
   end
 
   private

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -44,8 +44,9 @@ class Admin::ReportsController < Admin::BaseController
   end
 
   def destroy
+    report_date = @report.report_date
     @report.destroy
-    redirect_to admin_calendar_month_path, notice: '日報が削除されました。'
+    redirect_to admin_calendar_day_path(date: report_date), notice: '日報が削除されました。'
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     if resource.admin?
-      admin_calendar_day_path
+      admin_calendar_month_path
     else
       calendar_month_path
     end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -36,7 +36,7 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.build(report_params)
     if @report.save
-      redirect_to reports_path, notice: '日報が作成されました。'
+      redirect_to calendar_month_path, notice: '日報が作成されました。'
     else
       flash.now[:alert] = @report.formatted_error_messages
       render :new, status: :unprocessable_entity
@@ -45,7 +45,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      redirect_to reports_path, notice: '日報を更新しました。'
+      redirect_to calendar_month_path, notice: '日報を更新しました。'
     else
       flash.now[:alert] = @report.formatted_error_messages
       render :edit, status: :unprocessable_entity

--- a/app/views/admin/calendar/day.html.erb
+++ b/app/views/admin/calendar/day.html.erb
@@ -8,10 +8,6 @@
     <h1 class="fs-2 mb-0">
       <%= current_user.admin? ? "日報一覧(day)" : "日報一覧" %>
     </h1>
-    <%= link_to new_report_path, class: "btn btn-success" do %>
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="me-1" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
-      新規作成
-    <% end %>
   </div>
   <%= render_search_bar(path: admin_calendar_day_path) %>
 

--- a/app/views/admin/calendar/day.html.erb
+++ b/app/views/admin/calendar/day.html.erb
@@ -57,8 +57,8 @@
           <div class="me-2">
             <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>
           </div>
-          <%= link_to "詳細", report_path(report), class: "btn btn-primary btn-sm m-0 me-2" %>
-          <%= button_to "削除", report_path(report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>
+      <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm m-0 me-2" %>
+          <%= button_to "削除", admin_report_path(report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/calendar/day.html.erb
+++ b/app/views/admin/calendar/day.html.erb
@@ -13,7 +13,7 @@
       新規作成
     <% end %>
   </div>
-  <%= render_search_bar(path: reports_path) %>
+  <%= render_search_bar(path: admin_calendar_day_path) %>
 
   <div class="d-flex align-items-center justify-content-between my-3">
   <% prev_date = (@selected_date - 1.day).strftime("%Y-%m-%d") %>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -31,9 +31,21 @@
   </div>
 
   <div class="mt-4">
+    <% 
+      referer = request.referer.to_s
+      if referer.include?('admin/calendar/day')
+        button_text = '日報一覧へ戻る'
+        # URLからdate=XXXXの部分を抽出
+        date_param = referer.match(/date=([\d-]+)/)
+        back_path = date_param ? admin_calendar_day_path(date: date_param[1]) : admin_calendar_day_path
+      else
+        button_text = 'カレンダーへ戻る'
+        back_path = admin_calendar_month_path
+      end
+    %>
     <%= render 'share/bootstrap_dark_button',
-          text: '一覧へ戻る',
-          path: admin_calendar_month_path,
+          text: button_text,
+          path: back_path,
           size_class: 'btn-lg',
           extra_classes: 'custom-dark-button' %>
   </div>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -33,7 +33,7 @@
   <div class="mt-4">
     <%= render 'share/bootstrap_dark_button',
           text: '一覧へ戻る',
-          path: admin_reports_path,
+          path: admin_calendar_month_path,
           size_class: 'btn-lg',
           extra_classes: 'custom-dark-button' %>
   </div>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -3,7 +3,7 @@
 <% context ||= :user %> 
 
 <% form_url = (context == :admin) ? [:admin, report] : report %>
-<% cancel_path = (context == :admin) ? admin_reports_path : reports_path %>
+<% cancel_path = (context == :admin) ? admin_calendar_month_path : calendar_month_path %>
 
 <%= form_with model: report, url: form_url, local: true, html: { class: form_class } do |form| %>
   <div class="mb-4">

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -3,7 +3,11 @@
 <% context ||= :user %> 
 
 <% form_url = (context == :admin) ? [:admin, report] : report %>
-<% cancel_path = (context == :admin) ? admin_calendar_month_path : calendar_month_path %>
+<% cancel_path = if report.persisted? %>
+  <% (context == :admin) ? admin_report_path(report) : report_path(report) %>
+<% else %>
+  <% (context == :admin) ? admin_calendar_month_path : calendar_month_path %>
+<% end %>
 
 <%= form_with model: report, url: form_url, local: true, html: { class: form_class } do |form| %>
   <div class="mb-4">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -34,7 +34,7 @@
 
   <div class="mt-4">
     <%= render 'share/bootstrap_dark_button',
-          text: '一覧へ戻る',
+          text: 'カレンダーへ戻る',
           path: calendar_month_path,
           size_class: 'btn-lg',
           extra_classes: 'custom-dark-button' %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -35,7 +35,7 @@
   <div class="mt-4">
     <%= render 'share/bootstrap_dark_button',
           text: '一覧へ戻る',
-          path: reports_path,
+          path: calendar_month_path,
           size_class: 'btn-lg',
           extra_classes: 'custom-dark-button' %>
   </div>


### PR DESCRIPTION
## 概要

1. 日報登録・更新後の遷移先変更
	•	変更前：登録・更新後は一覧画面（reports_path, admin_reports_path）に戻っていた。
	•	変更後：登録・更新後はカレンダー月表示画面（calendar_month_path, admin_calendar_month_path）に戻るようになった。

⸻

2. 削除後の遷移先変更（管理者）
	•	変更前：削除後は一覧画面（admin_reports_path）に戻っていた。
	•	変更後：該当日を指定してカレンダー日表示画面（admin_calendar_day_path(date: ...)）に戻るようになった。

⸻

3. ログイン後の初期遷移先変更（管理者）
	•	変更前：admin_calendar_day_path（当日単位）に遷移
	•	変更後：admin_calendar_month_path（月単位表示）に遷移

⸻

4. 詳細画面の戻るボタンの挙動変更（管理者）
	•	変更前：常に一覧画面に戻っていた
	•	変更後：遷移元が日表示カレンダーなら日付付きで戻り、それ以外なら月表示カレンダーに戻る

⸻

5. フォームのキャンセル遷移先変更
	•	変更前：キャンセル時は一覧画面に戻っていた
	•	変更後：カレンダー月表示に戻るようになった(editの時はreport/idにnewの時はカレンダーへ)


## ISSUE

Close #146 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [x] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)


## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* passの確認
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

### 1. 日報登録・更新後の遷移
- [x] 日報を新規登録後、`calendar_month_path` に遷移すること
- [x] 日報を編集・更新後、`calendar_month_path` に遷移すること
- [x] 管理者ユーザーの場合、`admin_calendar_month_path` に遷移すること

### 2. 管理者による削除後の遷移
- [ ] 日報を削除後、該当日の `admin_calendar_day_path(date: ...)` に遷移すること

### 3. 管理者ログイン後の初期遷移
- [x] ログイン後、`admin_calendar_month_path` に遷移すること（当日単位ではない）

### 4. 詳細画面の「戻る」ボタン挙動
- [x] 遷移元が日カレンダー（`admin_calendar_day_path`）なら、その日付付きで戻ること
- [x] それ以外から来た場合は `admin_calendar_month_path` に戻ること

### 5. フォームキャンセル時の遷移
- [x] 日報新規作成または編集画面で「キャンセル」した際、`calendar_month_path` に遷移すること
- [ ] 管理者画面では `admin_calendar_month_path` に遷移すること
- [x] edit画面ではreport/idにと遷移すること
