### PR TITLE
#150 admin日報詳細画面で作成者表示

### DIFF
--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -1,7 +1,11 @@
 <div class="container mt-5">
   <div class="card shadow-sm mb-4">
     <div class="card-body">
-      <p class="mb-3"><%= @report.report_date.strftime("%Y-%m-%d") %></p>
+      <p class="mb-3">
+        <span><%= @report.report_date.strftime("%Y-%m-%d") %></span>
+        <span class="mx-1">/</span>
+        <span>作成者 <%= @report.user&.name %></span>
+      </p>
 
       <div class="d-flex justify-content-between align-items-center mb-3">
         <div class="d-flex align-items-center">


### PR DESCRIPTION
## 概要

現在、admin日報詳細画面で、作成者の表示がなく、詳細を見ている際にその日報が誰の日報なのかわからない。
作成者表示を以下の画像のように追加した。

![CleanShot 2025-05-02 at 13 24 38](https://github.com/user-attachments/assets/1614eb1e-aeaa-45a7-a0c5-be724853a741)

## ISSUE

close #150

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **UI/UX:** admin日報詳細ページの表示

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] adminで日報詳細画面を開いた時に、日付の横に作成者が表示されること
