### PR TITLE
Feature/123 アラートをモーダルで表示

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -602,3 +602,9 @@ button#menu-toggle {
 .form-switch-lg {
     transform: scale(1.3);
 }
+
+.btn-hover-red:hover {
+    background-color: #dc3545 !important;
+    color: #fff !important;
+    border-color: #dc3545 !important;
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import ToastController from "./toast_controller"
 application.register("toast", ToastController)
+
+import ModalController from "./modals_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modals_controller.js
+++ b/app/javascript/controllers/modals_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
+
+export default class extends Controller {
+  static targets = ["modal", "form"]
+
+  connect() {
+    this.bootstrapModal = new Modal(this.modalTarget)
+  }
+
+  show(event) {
+    const url = event.currentTarget.dataset.url
+    if (url && this.hasFormTarget) {
+      this.formTarget.action = url
+    }
+    this.bootstrapModal.show()
+  }
+
+  hide() {
+    this.bootstrapModal.hide()
+  }
+}

--- a/app/views/admin/calendar/day.html.erb
+++ b/app/views/admin/calendar/day.html.erb
@@ -50,8 +50,17 @@
           <div class="me-2">
             <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>
           </div>
-      <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm m-0 me-2" %>
-          <%= button_to "削除", admin_report_path(report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>
+          <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm m-0 me-2" %>
+          <div data-controller="modal">
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-dark btn-hover-red"
+              data-action="click->modal#show"
+              data-url="<%= admin_report_path(report) %>">
+              削除
+            </button>
+            <%= render partial: "share/delete_alert" %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -13,9 +13,20 @@
           <%= link_to edit_admin_report_path(@report), class: "btn btn-link text-secondary p-0 me-1 icon-hover", title: "編集", "data-bs-toggle": "tooltip", "data-bs-placement": "top" do %>
             <i class="bi bi-pencil-square fs-3 ms-3"></i>
           <% end %>
-          <%= button_to admin_report_path(@report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-link text-danger p-0 icon-hover", title: "削除", form: { style: 'display:inline-block;' }, "data-bs-toggle": "tooltip", "data-bs-placement": "top" do %>
-            <i class="bi bi-trash fs-3 me-3"></i>
-          <% end %>
+          <div data-controller="modal">
+            <button
+              type="button"
+              class="btn btn-link text-danger p-0 icon-hover"
+              data-action="click->modal#show"
+              data-url="<%= admin_report_path(@report) %>"
+              data-bs-toggle="tooltip"
+              data-bs-placement="top"
+              title="削除"
+            >
+              <i class="bi bi-trash fs-3"></i>
+            </button>
+            <%= render partial: "share/delete_alert" %>
+          </div>
         </div>
         <div class="ms-auto">
           <%= render partial: "reports/favorite", locals: { report: @report, favorite: @report.favorites.find_by(user_id: current_user.id) } %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -21,7 +21,16 @@
         <td><%= user.admin? ? "管理者" : "一般" %></td>
         <td class="d-flex align-items-center">
           <%= link_to "編集", edit_admin_user_path(user), class: "btn btn-sm me-2 btn-outline-dark" %>
-          <%= button_to "削除", admin_user_path(user), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-sm btn-outline-dark btn-hover-red" %>
+          <div data-controller="modal">
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-dark btn-hover-red"
+              data-action="click->modal#show"
+              data-url="<%= admin_user_path(user) %>">
+              削除
+            </button>
+            <%= render partial: "share/delete_alert" %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,8 +23,16 @@
               <% end %>
             </li>
             <li class="nav-item">
-              <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo_confirm: "本当にログアウトしますか？" },
-              class: "btn logout-button px-2 py-2" %>
+              <div data-controller="modal">
+                <button
+                  type="button"
+                  class="btn logout-button px-2 py-2"
+                  data-action="click->modal#show"
+                  data-url="<%= destroy_user_session_path %>">
+                  ログアウト
+                </button>
+                <%= render partial: "share/delete_alert", locals:{question_text:"本当にログアウトしますか？", confirm_button_text:"ログアウトする"}%>
+              </div>
             </li>
           </div>
         <% else %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -9,9 +9,20 @@
           <%= link_to edit_report_path(@report), class: "btn btn-link text-secondary p-0 me-1  icon-hover", title: "編集", "data-bs-toggle": "tooltip", "data-bs-placement": "top" do %>
             <i class="bi bi-pencil-square fs-3 ms-3"></i>
           <% end %>
-          <%= button_to report_path(@report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-link text-danger p-0 icon-hover", title: "削除", form: { style: 'display:inline-block;' }, "data-bs-toggle": "tooltip", "data-bs-placement": "top" do %>
-            <i class="bi bi-trash fs-3 me-3"></i>
-          <% end %>
+          <div data-controller="modal">
+            <button
+              type="button"
+              class="btn btn-link text-danger p-0 icon-hover"
+              data-action="click->modal#show"
+              data-url="<%= report_path(@report) %>"
+              data-bs-toggle="tooltip"
+              data-bs-placement="top"
+              title="削除"
+            >
+              <i class="bi bi-trash fs-3"></i>
+            </button>
+            <%= render partial: "share/delete_alert" %>
+          </div>
         </div>
         <div class="ms-auto">
           <%= render partial: "favorite", locals: { report: @report, favorite: @report.favorites.find_by(user_id: current_user.id) } %>

--- a/app/views/share/_delete_alert.html.erb
+++ b/app/views/share/_delete_alert.html.erb
@@ -1,0 +1,28 @@
+<% question_text = local_assigns[:question_text] || "本当に削除しますか？" %>
+<% confirm_button_text = local_assigns[:confirm_button_text] || "削除する" %>
+
+<div
+    class="modal fade"
+    tabindex="-1"
+    role="dialog"
+    data-modal-target="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+            <h5 class="modal-title">warning</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+            </div>
+            <div class="modal-body">
+                <%= question_text %>
+            </div>
+            <div class="modal-footer">
+            <button type="button" class="btn btn-sm btn-outline-dark" data-bs-dismiss="modal">キャンセル</button>
+            <form data-modal-target="form" method="post">
+                <input type="hidden" name="_method" value="delete" />
+                <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
+                <button type="submit" class="btn btn-sm btn-outline-dark btn-hover-red"><%= confirm_button_text %></button>
+            </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/share/_reports_table.html.erb
+++ b/app/views/share/_reports_table.html.erb
@@ -29,7 +29,16 @@
             <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>
           </div>
           <%= link_to "詳細", admin ? admin_report_path(report) : report_path(report), class: "btn btn-sm m-0 me-2 btn-outline-dark" %>
-          <%= button_to "削除", admin ? admin_report_path(report) : report_path(report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-sm btn-outline-dark btn-hover-red" %>
+          <div data-controller="modal">
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-dark btn-hover-red"
+              data-action="click->modal#show"
+              data-url="<%= report_path(report) %>">
+              削除
+            </button>
+            <%= render partial: "share/delete_alert" %>
+          </div>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
## 概要

window.alertではなく、bootstrapのモーダルでアラート内容を表示する

日報・ユーザー削除
<img width="567" alt="image" src="https://github.com/user-attachments/assets/399458c8-fc80-4b81-bb40-9905ba0c045c" />

ログアウト時
<img width="599" alt="image" src="https://github.com/user-attachments/assets/fcdcd9c3-9cbf-460d-8e7d-768627077b88" />


## ISSUE

close #123 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** (例: ログイン機能、商品一覧ページ、決済処理)
* **UI/UX:** (例: ヘッダーのデザイン変更、ボタンの配置変更)
* **データベース:** (例: `users`テーブルに`last_login_at`カラム追加)
* **外部連携:** (例: 〇〇APIへのリクエストパラメータ変更)
* **影響なし**

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [x] 削除ボタンを押すと、モーダルが表示される
* [x] モーダルの削除ボタンを押すと、該当のデータが削除され、モーダルがとじる
* [x] モーダルの罰ボタン or キャンセルを押すと、モーダルがとじる 

### 以下のボタンを押した時のアラートがモーダルに置き換わっている
* [x] 一般日報一覧ページ(リスト)の削除ボタン
* [x] admin日別日報一覧ページの削除ボタン
* [x] 従業員一覧ページの削除ボタン
* [x] admin日報詳細ページの削除ボタン
* [x] 一般日報詳細ページの削除ボタン

