### PR TITLE
#161 admin 日報一覧（day）を共通化

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -480,7 +480,6 @@ button#menu-toggle {
         justify-content: center;
         padding: 5px 20px;
         border-radius: 9999px;
-        border: 1px solid #000;
         color: #000;
         text-decoration: none;
         font-size: 0.8rem;
@@ -717,7 +716,6 @@ button#menu-toggle {
 .search_bar_input {
     border-radius: 23px;
     background-color: #ececec;
-    border: 1px solid #000;
     padding: 8px 12px 8px 17px;
     outline: none;
     transition: background-color 0.3s ease;

--- a/app/controllers/admin/calendar_controller.rb
+++ b/app/controllers/admin/calendar_controller.rb
@@ -8,12 +8,12 @@ class Admin::CalendarController < Admin::BaseController
     # start_date = params[:start_date]
     # end_date   = params[:end_date]
     # keyword    = params[:q]
-    # sort       = params[:sort]
-    # direction  = params[:direction]
+    sort       = params[:sort]
+    direction  = params[:direction]
     # @favorite_only = ActiveModel::Type::Boolean.new.cast(params[:favorite_only])
 
     @reports = Report.includes(:user)
-    @reports = @reports.where(report_date: @selected_date).keyword_search(params[:q])
+    @reports = @reports.where(report_date: @selected_date).keyword_search(params[:q]).sorted_by(sort, direction)
 
     return unless ActiveModel::Type::Boolean.new.cast(params[:favorite_only])
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -6,7 +6,7 @@ class Report < ApplicationRecord
   has_many :favorite_users, through: :favorites, source: :user
 
   scope :sorted_by, ->(column, direction) {
-    column = %w[report_date title].include?(column) ? column : "report_date"
+    column = %w[report_date title created_at].include?(column) ? column : "report_date"
     direction = %w[asc desc].include?(direction) ? direction : "desc"
     order(column => direction)
   }

--- a/app/views/admin/calendar/day.html.erb
+++ b/app/views/admin/calendar/day.html.erb
@@ -25,35 +25,4 @@
   <%= link_to "翌日 →",admin_calendar_day_path(date: next_date), class: "btn btn-outline-secondary" %>
 </div>
 
-
-  <table class="table table-striped">
-  <thead class="table-dark">
-    <tr>
-      <th>ID</th>
-      <th>タイトル</th>
-      <th>作成者</th>
-      <th>
-        作成時刻
-        <%= sort_arrow("report_date") %>
-      </th>
-      <th>操作</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @reports.each do |report| %>
-      <tr>
-        <td><%= report.id %></td>
-        <td><%= report.title %></td>
-        <td><%= report.user&.name %></td>
-        <td><%= report.created_at.strftime("%H:%M") %></td>
-        <td class="d-flex align-items-center">
-          <div class="me-2">
-            <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>
-          </div>
-      <%= link_to "詳細", admin_report_path(report), class: "btn btn-primary btn-sm m-0 me-2" %>
-          <%= button_to "削除", admin_report_path(report), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "btn btn-danger btn-sm" %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render partial: "share/reports_table", locals: { reports: @reports, admin: true } %>

--- a/app/views/admin/calendar/day.html.erb
+++ b/app/views/admin/calendar/day.html.erb
@@ -1,6 +1,6 @@
 <div class="calendar-header">
   <div class="calendar-header-left">
-    <%= link_to '今日', admin_calendar_day_path(date: Date.today.strftime('%Y-%m-%d')), class: 'today-button' %>
+    <%= link_to '今日', admin_calendar_day_path(date: Date.today.strftime('%Y-%m-%d')), class: 'today-button border' %>
     <div class="arrow-buttons">
       <%= link_to admin_calendar_day_path(date: @previous_date), class: 'arrow-button' do %>
         <i class="bi bi-chevron-left"></i>

--- a/app/views/admin/calendar/month.html.erb
+++ b/app/views/admin/calendar/month.html.erb
@@ -1,6 +1,6 @@
 <div class="calendar-header">
   <div class="calendar-header-left">
-    <%= link_to '今月', admin_calendar_month_path(month: Date.today.strftime('%Y-%m')), class: 'today-button' %>
+    <%= link_to '今月', admin_calendar_month_path(month: Date.today.strftime('%Y-%m')), class: 'today-button border' %>
     <div class="arrow-buttons">
       <%= link_to admin_calendar_month_path(month: @prev_month), class: 'arrow-button' do %>
         <i class="bi bi-chevron-left"></i>
@@ -85,4 +85,3 @@
     <% end %>
   </tbody>
 </table>
-

--- a/app/views/calendar/month.html.erb
+++ b/app/views/calendar/month.html.erb
@@ -2,7 +2,7 @@
 <div class="user-calendar-container mb-4">
   <div class="calendar-header">
     <div class="calendar-header-left">
-      <%= link_to '今月', calendar_month_path(month: Date.today.strftime('%Y-%m')), class: 'today-button' %>
+      <%= link_to '今月', calendar_month_path(month: Date.today.strftime('%Y-%m')), class: 'today-button border' %>
       <div class="arrow-buttons">
         <%= link_to calendar_month_path(month: @prev_month), class: 'arrow-button' do %>
           <i class="bi bi-chevron-left"></i>

--- a/app/views/share/_reports_table.html.erb
+++ b/app/views/share/_reports_table.html.erb
@@ -3,17 +3,19 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <th>タイトル</th>
+      <th class="align-middle">タイトル</th>
       <% if admin %>
-        <th>作成者</th>
+        <th class="align-middle">作成者</th>
       <% end %>
-      <th>
-        日付
-        <%if sort_enabled %>
-          <%= sort_arrow("report_date") %>
-        <% end %>
-      </th>
-      <th>操作</th>
+      <% if !admin %>
+        <th class="align-middle">
+          日付
+          <%if sort_enabled %>
+            <%= sort_arrow("report_date") %>
+          <% end %>
+        </th>
+      <% end %>
+      <th class="align-middle">操作</th>
     </tr>
   </thead>
   <tbody>
@@ -23,7 +25,9 @@
         <% if admin %>
           <td><%= report.user&.name %></td>
         <% end %>
-        <td><%= report.report_date.strftime("%Y-%m-%d") %></td>
+        <% if !admin %>
+          <td><%= report.report_date.strftime("%Y-%m-%d") %></td>
+        <% end %>
         <td class="d-flex align-items-center">
           <div class="me-2">
             <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>

--- a/app/views/share/_reports_table.html.erb
+++ b/app/views/share/_reports_table.html.erb
@@ -38,7 +38,7 @@
               type="button"
               class="btn btn-sm btn-outline-dark btn-hover-red"
               data-action="click->modal#show"
-              data-url="<%= report_path(report) %>">
+              data-url="<%= admin ? admin_report_path(report) : report_path(report) %>">
               削除
             </button>
             <%= render partial: "share/delete_alert" %>

--- a/app/views/share/_reports_table.html.erb
+++ b/app/views/share/_reports_table.html.erb
@@ -7,14 +7,12 @@
       <% if admin %>
         <th class="align-middle">作成者</th>
       <% end %>
-      <% if !admin %>
-        <th class="align-middle">
-          日付
-          <%if sort_enabled %>
-            <%= sort_arrow("report_date") %>
-          <% end %>
-        </th>
-      <% end %>
+      <th class="align-middle">
+        <%= admin ? "作成時刻" : "日付" %>
+        <%if sort_enabled %>
+          <%= sort_arrow(admin ? "created_at" : "report_date") %>
+        <% end %>
+      </th>
       <th class="align-middle">操作</th>
     </tr>
   </thead>
@@ -25,9 +23,8 @@
         <% if admin %>
           <td><%= report.user&.name %></td>
         <% end %>
-        <% if !admin %>
-          <td><%= report.report_date.strftime("%Y-%m-%d") %></td>
-        <% end %>
+        <td><%= admin ? report.created_at.strftime("%H:%M") : report.report_date.strftime("%Y-%m-%d") %></td>
+
         <td class="d-flex align-items-center">
           <div class="me-2">
             <%= render partial: "reports/favorite", locals: { report: report, favorite: report.favorites.find_by(user_id: current_user.id) } %>

--- a/app/views/share/_search_bar.html.erb
+++ b/app/views/share/_search_bar.html.erb
@@ -3,7 +3,7 @@
   <div class="position-relative w-100">
     <%= f.label :q, "キーワード検索", class: "form-label visually-hidden" %>
     <div class="me-2 flex-grow-1">
-      <%= f.text_field :q, value: params[:q], class: "search_bar_input", placeholder: placeholder %>
+      <%= f.text_field :q, value: params[:q], class: "search_bar_input border", placeholder: placeholder %>
     </div>
     <div class="position-absolute search_bar_submit">
       <button type="submit" class="btn">


### PR DESCRIPTION
## 概要

adminの日報一覧(day)を一般の方と共通化。
adminの日報一覧(day)は、日付カラムが要らないので消した

![ClanShot 2025-05-07 at 14 26 37](https://github.com/user-attachments/assets/1b7dd65f-dfe8-4e21-8125-9a014833b589)

## ISSUE

close #161

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [x] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **UI/UX:** adminの日報一覧部分

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] 該当日の日報が正しく表示されること
* [ ] 遷移先リンクが正しいこと
