### PR TITLE
#171 キャンセルボタンの遷移先変更

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -31,6 +31,12 @@ class ReportsController < ApplicationController
 
   def new
     @report = current_user.reports.build
+    if params[:date].present?
+      selected_month = Date.parse(params[:date]).strftime('%Y-%m')
+      @cancel_path = calendar_month_path(month: selected_month)
+    else
+      @cancel_path = calendar_month_path
+    end
   end
 
   def create

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -9,6 +9,10 @@
   <% (context == :admin) ? admin_calendar_month_path : calendar_month_path %>
 <% end %>
 
+
+<% cancel_path = @cancel_path if defined?(@cancel_path) && @cancel_path.present? %>
+
+
 <%= form_with model: report, url: form_url, local: true, html: { class: form_class } do |form| %>
   <div class="mb-4">
     <div class="d-flex align-items-center mb-2">

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5">
   <div class="card shadow-sm mb-4">
     <div class="card-body">
-      <%= render 'form', report: @report, form_class: 'new-form' %>
+      <%= render 'form', report: @report, form_class: 'new-form', cancel_path: @cancel_path %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- 個人ページにて、当月以外のカレンダーから、日報を追加画面に遷移後、キャンセルボタンを押すと、遷移元の月カレンダー
に戻るようにした。

以下の項目を参考に、変更の概要を記載してください。

* 変更の背景と目的
 個人ページから、カレンダーの当月以外から、新規追加するページに遷移後、キャンセルをクリックすると、今月のページに遷移してしまう。

ex)
３月から新規追加ページに遷移した場合、キャンセルした場合、３月のカレンダーに戻ってほしい。

## ISSUE
Closes #171 

該当するISSUEリンク

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** (例: ログイン機能、商品一覧ページ、決済処理)
* **UI/UX:** (例: ヘッダーのデザイン変更、ボタンの配置変更)
* **データベース:** (例: `users`テーブルに`last_login_at`カラム追加)
* **外部連携:** (例: 〇〇APIへのリクエストパラメータ変更)
* **影響なし**

## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] (例) 期待通りにページが表示されることを確認した
