### PR TITLE
#184 UI/UX微調整

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -472,7 +472,7 @@ button#menu-toggle {
         align-items: center;
         height: 100%;
         gap: 15px;
-        width: 40%;
+        width: 50%;
     }
 
     .today-button {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -759,14 +759,21 @@ button#menu-toggle {
     transform: scale(1.3);
 }
 
-.favorite-only-toggle .form-check-input:checked {
-    background-color: #6c757d;
-    border-color: #6c757d;
-}
 
-.favorite-only-toggle .form-check-input:focus {
-    box-shadow: none !important;
-    outline: none !important;
+.favorite-only-toggle {
+    .form-check-input:checked {
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+    .form-check-input:focus {
+        box-shadow: none !important;
+        outline: none !important;
+        border-color: #6c757d !important;
+        --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%236c757d'/%3e%3c/svg%3e");
+    }
+    .form-check-input {
+        border-color: #6c757d !important;
+    }
 }
 
 .btn-hover-red:hover {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -485,6 +485,7 @@ button#menu-toggle {
         text-decoration: none;
         font-size: 0.8rem;
         height: 40px;
+        transition: background-color 0.3s ease;
 
         &:hover {
             background-color: #dadada;
@@ -539,6 +540,7 @@ button#menu-toggle {
     text-align: center;
     font-weight: bold;
     margin: 0 auto;
+    transition: background-color 0.3s ease;
 }
 
 .user-calendar {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -784,3 +784,7 @@ button#menu-toggle {
         text-decoration: underline;
     }
 }
+
+.no-border {
+    border: none !important;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -772,3 +772,7 @@ button#menu-toggle {
     color: #fff !important;
     border-color: #dc3545 !important;
 }
+
+.cursor-pointer {
+    cursor: pointer;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -776,3 +776,9 @@ button#menu-toggle {
 .cursor-pointer {
     cursor: pointer;
 }
+
+.header-link {
+    &:hover {
+        text-decoration: underline;
+    }
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,7 +1,19 @@
-/* カスタム背景や余白、フォントサイズの調整など */
+/* フォントファミリーの設定 */
+:root {
+    --font-family-base: 'Noto Sans', 'Noto Sans JP', sans-serif;
+}
+
+/* サイト全体にフォントを適用 */
 body {
+    font-family: var(--font-family-base);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     background-color: #f8f9fa;
-    /* 薄いグレー背景 */
+}
+
+/* 見出しにも同じフォントを適用 */
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-family-base);
 }
 
 h1 {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
     link_to url_for(base_params), class: 'd-flex align-items-center text-decoration-none favorite-only-toggle' do
       content_tag(:div, class: 'd-flex align-items-center gap-2') do
         content_tag(:div, class: 'form-check form-switch') do
-          content_tag(:input, '', type: 'checkbox', class: 'form-check-input form-switch-lg', checked: is_favorite) +
+          content_tag(:input, '', type: 'checkbox', class: 'form-check-input form-switch-lg cursor-pointer', checked: is_favorite) +
             content_tag(:div, class: 'd-flex align-items-center') do
               content_tag(:span, 'いいねのみ表示', class: 'text-dark')
             end

--- a/app/views/admin/calendar/month.html.erb
+++ b/app/views/admin/calendar/month.html.erb
@@ -58,9 +58,9 @@
                 <div class="report-item">
                   <%= link_to request.path.start_with?('/admin') ? admin_report_path(report) : report_path(report), class: "d-flex align-items-center gap-1" do %>
                     <% if defined?(current_user) && report.favorites.exists?(user_id: current_user.id) %>
-                      <i class="bi bi-heart-fill"></i>
+                      <i class="bi bi-suit-heart-fill text-danger"></i>
                     <% else %>
-                      <i class="bi bi-heart"></i>
+                      <i class="bi bi-suit-heart"></i>
                     <% end %>
                     <% if request.path.start_with?('/admin') %>
                       <span class="report-content"><%= report.user.name %></span>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -62,6 +62,6 @@
           text: button_text,
           path: back_path,
           size_class: 'btn-lg',
-          extra_classes: 'btn btn-lg btn-outline-dark btn-hover-red' %>
+          extra_classes: 'btn btn-lg btn-outline-dark' %>
   </div>
 </div>

--- a/app/views/calendar/month.html.erb
+++ b/app/views/calendar/month.html.erb
@@ -59,7 +59,7 @@
   <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5 class="mb-0">最近の日報</h5>
-      <%= link_to '日報一覧へ', reports_path, class: 'btn btn-outline-primary btn-sm' %>
+      <%= link_to '日報一覧へ', reports_path, class: 'btn btn-outline-dark btn-sm' %>
     </div>
     <div class="list-group list-group-flush">
       <% if @recent_reports.any? %>

--- a/app/views/calendar/month.html.erb
+++ b/app/views/calendar/month.html.erb
@@ -56,7 +56,7 @@
 
 <%# 最近の日報セクション %>
 <div class="recent-reports-container">
-  <div class="card">
+  <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5 class="mb-0">最近の日報</h5>
       <%= link_to '日報一覧へ', reports_path, class: 'btn btn-outline-primary btn-sm' %>

--- a/app/views/calendar/month.html.erb
+++ b/app/views/calendar/month.html.erb
@@ -56,7 +56,7 @@
 
 <%# 最近の日報セクション %>
 <div class="recent-reports-container">
-  <div class="card mb-4">
+  <div class="card no-border mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5 class="mb-0">最近の日報</h5>
       <%= link_to '日報一覧へ', reports_path, class: 'btn btn-outline-dark btn-sm' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -34,7 +34,7 @@
         </div>
         <div class="card-footer text-center">
           <p class="mb-1">すでにアカウントをお持ちですか？</p>
-          <%= link_to "ログイン", new_session_path(resource_name)%>
+          <%= link_to "ログイン", new_session_path(resource_name), class: "nav-link text-dark text-decoration-underline" %>
         </div>
       </div>
     </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "新規ユーザー登録", new_registration_path(resource_name) %><br />
+  <%= link_to "新規ユーザー登録", new_registration_path(resource_name), class: "nav-link text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,9 +4,9 @@
       <%= link_to "日報管理システム", root_path, class: "navbar-brand text-dark fw-bold" %>
         <% if user_signed_in? && current_user.admin? %>
           <% if request.path.start_with?('/admin') %>
-            <%= link_to "個人ページへ", calendar_month_path, class: "nav-link text-dark fw-bold text-decoration-underline me-3" %>
+            <%= link_to "個人ページへ", calendar_month_path, class: "nav-link text-dark fw-bold header-link me-3" %>
           <% else %>
-            <%= link_to "管理者ページへ", admin_calendar_month_path, class: "nav-link text-dark fw-bold text-decoration-underline me-3" %>
+            <%= link_to "管理者ページへ", admin_calendar_month_path, class: "nav-link text-dark fw-bold header-link me-3" %>
           <% end %>
         <% end %>
       <ul class="navbar-nav ms-auto">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,10 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>

--- a/app/views/reports/_favorite.html.erb
+++ b/app/views/reports/_favorite.html.erb
@@ -1,11 +1,11 @@
 <turbo-frame id="favorite-button-<%= report.id %>">
   <% if favorite&.id %>
     <%= button_to report_favorite_path(report, favorite), method: :delete, class: "btn btn-link p-0" do %>
-      <i class="bi bi-heart-fill text-danger fs-3"></i>
+      <i class="bi bi-suit-heart-fill text-danger fs-3"></i>
     <% end %>
   <% else %>
     <%= button_to report_favorites_path(report), method: :post, class: "btn btn-link p-0" do %>
-      <i class="bi bi-heart-fill text-secondary fs-3"></i>
+      <i class="bi bi-suit-heart text-secondary fs-3"></i>
     <% end %>
   <% end %>
 </turbo-frame>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -48,7 +48,7 @@
           text: 'カレンダーへ戻る',
           path: calendar_month_path,
           size_class: 'btn-lg',
-          extra_classes: 'btn btn-lg btn-outline-dark btn-hover-red' %>
+          extra_classes: 'btn btn-lg btn-outline-dark' %>
   </div>
 
 </div>


### PR DESCRIPTION
## 概要

UI/UXの微調整を実施して、見栄えの向上を図る。
- [x] ハートをスタイリッシュなものに変更
- [x] ハートのデザインをカレンダーとリストで統一
![CleanShot 2025-05-07 at 22 25 16](https://github.com/user-attachments/assets/66d8a7a5-37ce-44bc-bf1f-01bc378e8371)

- [x] 最近の日報の下に余白ほしい
- [x] 最近の日報のボタンを青から白黒に変更
![CleanShot 2025-05-07 at 22 25 34](https://github.com/user-attachments/assets/be1ce054-c3ca-4bb8-a3c8-3c429a1cc2ab)

- [x] お気に入りをクリックしたときに一瞬青くなるのをなくしたい
https://github.com/user-attachments/assets/a1c0db9f-6f3a-46c7-9250-7c448533a96a


- [x] フォントを揃える
- [x] カレンダーと最近の日報の枠線を揃える
![CleanShot 2025-05-07 at 22 26 24](https://github.com/user-attachments/assets/64af2967-c4ac-4ebb-97f9-d5aff73dbbf2)

- [x] hover時のtransitionを入れたい
![CleanShot 2025-05-07 at 22 28 10](https://github.com/user-attachments/assets/fd0e98c3-350e-4cf3-b7ba-c199db8a6865)


- [x] header の `管理者ページへ`、`個人ページへ` デフォルトで下線引かれているが、hover時下線にしたい。
https://github.com/user-attachments/assets/1f767162-49c9-4d35-9d8a-27321d9c54f1

- [x] ボタンやリンク系の pointerをcursorにしたい（矢印→マウス）

- [x] admin/日別日報の検索のプレイスホルダーが溢れている
https://github.com/user-attachments/assets/30302b22-d89f-4243-aa3b-fcdef6e2955c


- [x] キャンセルボタンにホバーすると赤色になる（黒で良いのでは


- [x] ログイン・サインアップのリンクが青色なので、黒色にする
![CleanShot 2025-05-07 at 22 28 36](https://github.com/user-attachments/assets/f42bb595-997a-4f15-8623-68be13512715)

## ISSUE

close #84

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [x] その他 (Other): UI/UX

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **UI/UX:** 上記修正部全体。


## レビュアーへのコメント (任意 / 推奨)

* 特に重点的にレビューしてほしい箇所はどこですか？
* 実装上の懸念点や、相談したい事項はありますか？
* 動作確認に必要な情報（環境変数、特定の手順など）があれば記述してください。

## QA (確認事項)

確認したことをリストアップしてください。

* [ ] 一番上で修正した項目が反映されていること
