### PR TITLE
#187 検索するカラムを指定できるようにする

### DIFF
--- a/app/controllers/admin/calendar_controller.rb
+++ b/app/controllers/admin/calendar_controller.rb
@@ -13,7 +13,9 @@ class Admin::CalendarController < Admin::BaseController
     # @favorite_only = ActiveModel::Type::Boolean.new.cast(params[:favorite_only])
 
     @reports = Report.includes(:user)
-    @reports = @reports.where(report_date: @selected_date).keyword_search(params[:q]).sorted_by(sort, direction)
+    @reports = @reports.where(report_date: @selected_date)
+                       .keyword_search(params[:q], ["users.name, reports.title"])
+                       .sorted_by(sort, direction)
 
     return unless ActiveModel::Type::Boolean.new.cast(params[:favorite_only])
 
@@ -49,7 +51,7 @@ class Admin::CalendarController < Admin::BaseController
     # 期間内の全レポートを取得
     all_reports = Report.includes(:user, :favorites)
                         .where(report_date: start_date.beginning_of_day..end_date.end_of_day)
-                        .keyword_search(params[:q])
+                        .keyword_search(params[:q], ["users.name"])
 
     if ActiveModel::Type::Boolean.new.cast(params[:favorite_only])
       favorite_report_ids = current_user.favorites.pluck(:report_id)

--- a/app/controllers/admin/calendar_controller.rb
+++ b/app/controllers/admin/calendar_controller.rb
@@ -14,7 +14,7 @@ class Admin::CalendarController < Admin::BaseController
 
     @reports = Report.includes(:user)
     @reports = @reports.where(report_date: @selected_date)
-                       .keyword_search(params[:q], ["users.name, reports.title"])
+                       .keyword_search(params[:q], ["users.name", "reports.title"])
                        .sorted_by(sort, direction)
 
     return unless ActiveModel::Type::Boolean.new.cast(params[:favorite_only])

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,7 +20,7 @@ class ReportsController < ApplicationController
 
     @reports = @reports
                  .sorted_by(sort, direction)
-                 .keyword_search(keyword)
+                 .keyword_search(keyword, ["reports.title", "reports.contents"])
     if @favorite_only
       favorite_report_ids = current_user.favorites.pluck(:report_id)
       @reports = @reports.where(id: favorite_report_ids)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,6 +5,19 @@ class Report < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_users, through: :favorites, source: :user
 
+  # テーブル名とモデルクラスの対応を定義
+  TABLE_MAPPINGS = {
+    'reports' => { model: Report, table: arel_table },
+    'users' => { model: User, table: User.arel_table }
+  }.freeze
+
+  # デフォルトの検索カラムを定義
+  DEFAULT_SEARCH_COLUMNS = [
+    TABLE_MAPPINGS['reports'][:table][:title],
+    TABLE_MAPPINGS['reports'][:table][:contents],
+    TABLE_MAPPINGS['users'][:table][:name]
+  ].freeze
+
   scope :sorted_by, ->(column, direction) {
     column = %w[report_date title created_at].include?(column) ? column : "report_date"
     direction = %w[asc desc].include?(direction) ? direction : "desc"
@@ -14,19 +27,62 @@ class Report < ApplicationRecord
   scope :by_date_range, ->(start_date, end_date) {
     where(report_date: start_date..end_date) if start_date.present? && end_date.present?
   }
-  scope :keyword_search, ->(kw) {
+
+  scope :keyword_search, ->(kw, search_columns = nil) {
     return all if kw.blank?
 
-    # reports の title, contents と user.name を部分一致で検索
-    reports_table = arel_table
-    users_table   = User.arel_table
+    conditions = []
 
-    title_match = reports_table[:title].matches("%#{kw}%")
-    contents_match = reports_table[:contents].matches("%#{kw}%")
-    user_name_match = users_table[:name].matches("%#{kw}%")
+    # 検索対象のカラムを決定
+    search_columns = if search_columns.present?
+                       begin
+                         search_columns.map do |col|
+                           # 文字列でない場合はスキップ
+                           next unless col.is_a?(String)
 
-    joins(:user)
-      .where(title_match.or(contents_match).or(user_name_match))
+                           table_name, column_name = col.split('.')
+                           # テーブル名とカラム名の形式チェック
+                           unless table_name.present? && column_name.present?
+                             Rails.logger.warn("Invalid column format: #{col}. Expected format: 'table.column'")
+                             next
+                           end
+
+                           # テーブル情報を取得
+                           table_info = TABLE_MAPPINGS[table_name]
+                           unless table_info
+                             Rails.logger.warn("Unknown table: #{table_name}")
+                             next
+                           end
+
+                           # カラムが存在するか確認
+                           unless table_info[:model].column_names.include?(column_name)
+                             Rails.logger.warn("Column #{column_name} does not exist in table #{table_name}")
+                             next
+                           end
+
+                           table_info[:table][column_name]
+                         end.compact
+                       rescue ArgumentError
+                         Rails.logger.warn("Invalid format for search_columns: #{search_columns}")
+                         DEFAULT_SEARCH_COLUMNS
+                       end
+                     else
+                       DEFAULT_SEARCH_COLUMNS
+                     end
+
+    # 検索条件が空の場合はデフォルトの検索カラムを使用
+    if search_columns.empty?
+      Rails.logger.warn("No valid search columns found. Using default columns.")
+      search_columns = DEFAULT_SEARCH_COLUMNS
+    end
+
+    # 検索条件を構築
+    search_columns.each do |column|
+      conditions << column.matches("%#{kw}%")
+    end
+
+    # 条件を結合して検索を実行
+    joins(:user).where(conditions.reduce(:or))
   }
 
   # validates :date, presence: true


### PR DESCRIPTION
## 概要

placeholderに検索するカラムの指定があるのに、実際にはusers.name, reports.title, reports.contents全て検索対象になっているため、検索バーごとに絞り込みを行うようにした。

ただし、form_withのmethodはGETとなっているため、view側からカラムを指定するようにすると、URLクエリにテーブル名とカラム名が含まれるようになってしまった。
回避しようと頑張ったが、GETである以上難しそうだった。

## ISSUE

close #187

## 変更の種類 (必須)

該当するものをチェックしてください。

* [x] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [ ] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)

## 影響範囲 (必須)

変更が影響を与える可能性のある範囲を記述してください。

* **機能面:** 日報検索で検索対象となるカラムを変更

## レビュアーへのコメント (任意 / 推奨)


## QA (確認事項)

確認したことをリストアップしてください。

* [ ] adminのday表示で、ユーザー名とタイトルだけで検索できること(内容が検索に引っかからないこと)
* [ ] adminのカレンダー表示で、ユーザー名のみ検索できること(タイトル・内容で検索に引っかからないこと)
* [ ] 一般のリスト検索で、内容とタイトルのみで検索できること(ユーザー名で検索できないこと)
