### PR TITLE
Fix/201 直接editに飛んだ時のパスエラーを解消

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -39,13 +39,7 @@ class Admin::ReportsController < Admin::BaseController
 
   def update
     if @report.update(report_params)
-      if session[:return_to_admin_calendar]
-        redirect_to session[:return_to_admin_calendar], notice: '日報を更新しました。'
-      else
-        redirect_to admin_report_path(@report), notice: '日報を更新しました。'
-      end
-      # end
-      # redirect_to admin_report_path(@report), notice: '日報を更新しました。'
+      redirect_to admin_report_path(@report), notice: '日報を更新しました。'
     else
       @admin_context = true
       flash.now[:alert] = @report.formatted_error_messages

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -31,11 +31,21 @@ class Admin::ReportsController < Admin::BaseController
 
   def edit
     @admin_context = true
+    if request.referer&.include?('admin/calendar/day')
+      @cancel_path = request.referer
+      session[:return_to_admin_calendar] = request.referer
+    end
   end
 
   def update
     if @report.update(report_params)
-      redirect_to admin_report_path(@report), notice: '日報を更新しました。'
+      if session[:return_to_admin_calendar]
+        redirect_to session[:return_to_admin_calendar], notice: '日報を更新しました。'
+      else
+        redirect_to admin_report_path(@report), notice: '日報を更新しました。'
+      end
+      # end
+      # redirect_to admin_report_path(@report), notice: '日報を更新しました。'
     else
       @admin_context = true
       flash.now[:alert] = @report.formatted_error_messages

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -67,6 +67,8 @@ class ReportsController < ApplicationController
     # カレンダー日別画面からきた場合、キャンセル時の戻り先をその画面に設定
     if request.referer&.include?('reports')
       @cancel_path = request.referer
+    elsif request.referer&.include?('calendar')
+      @cancel_path = request.referer
     end
     render locals: { hide_sub_header: true }
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -64,12 +64,20 @@ class ReportsController < ApplicationController
   end
 
   def edit
+    # カレンダー日別画面からきた場合、キャンセル時の戻り先をその画面に設定
+    if request.referer&.include?('reports')
+      @cancel_path = request.referer
+    end
     render locals: { hide_sub_header: true }
   end
 
   def update
     if @report.update(report_params)
-      redirect_to report_path(@report), notice: '日報を更新しました。'
+      if request.referer&.include?('reports')
+        redirect_to reports_path, notice: '日報を更新しました。'
+      else
+        redirect_to report_path(@report), notice: '日報を更新しました。'
+      end
     else
       flash.now[:alert] = @report.formatted_error_messages
       render :edit, locals: { hide_sub_header: true }, status: :unprocessable_entity

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -74,7 +74,6 @@ class ReportsController < ApplicationController
   def update
     if @report.update(report_params)
       redirect_to report_path(@report), notice: '日報を更新しました。'
-      end
     else
       flash.now[:alert] = @report.formatted_error_messages
       render :edit, locals: { hide_sub_header: true }, status: :unprocessable_entity

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -73,10 +73,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      if request.referer&.include?('reports')
-        redirect_to reports_path, notice: '日報を更新しました。'
-      else
-        redirect_to report_path(@report), notice: '日報を更新しました。'
+      redirect_to report_path(@report), notice: '日報を更新しました。'
       end
     else
       flash.now[:alert] = @report.formatted_error_messages


### PR DESCRIPTION
## 概要

(一般)一覧から直接editに飛んだ時、キャンセルボタンと更新ボタンを正常に動くようにした
(admin)caledar/datから直接editに飛んだ時、キャンセルボタンと更新ボタンを正常に動くようにした

## ISSUE

Close #201 

## 変更の種類 (必須)

該当するものをチェックしてください。

* [ ] バグ修正 (Bug fix)
* [ ] 新機能 (New feature)
* [x] 機能改善 (Enhancement)
* [ ] リファクタリング (Refactoring)
* [ ] ドキュメント更新 (Documentation update)
* [ ] パフォーマンス改善 (Performance improvement)
* [ ] テスト追加・修正 (Test addition/modification)
* [ ] CI/CD関連 (CI/CD related)
* [ ] その他 (Other): (具体的に記述)


## QA (確認事項)

確認したことをリストアップしてください。

* [ ]  期待通りに動作することを確認した
